### PR TITLE
✨ feat: Add support for nested package.json and auto-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to the "package-scripts-hover" extension will be documented 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+## [0.1.0] - 2024-05-29
 
-- Initial release
+- Add support for nested structures by scanning all package.json files in the workspace and using a nested structure in `.vscode/script-docs.json`.
+- Implement automatic conversion of old `.vscode/script-docs.json` format to the new nested structure upon loading.
+- Add automatic documentation cache reload when `.vscode/script-docs.json` is changed, created, or deleted (with debounce).
+- Update `createDocs` command to scan all package.json files and merge into the central `.vscode/script-docs.json`.
+
+## [0.0.2] - 2024-03-26
+
+#### Added
+
+- New commands for extension management:
+  - `Enable Package Scripts Hover`: Manually enable hover functionality
+  - `Disable Package Scripts Hover`: Manually disable hover functionality
+  - `Reload Custom Docs`: Force reload documentation cache
+  - `Create Script Documentation Template`: Automatically generate script-docs.json template from package.json
+- Automatic script documentation template generation:
+  - Creates .vscode directory if needed
+  - Generates script-docs.json with default descriptions
+  - Asks for confirmation before overwriting existing file
+  - Opens generated file for immediate editing
+
+### 0.0.1
+
+Initial release of Package Scripts Hover
+
+## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ VS Code extension that shows helpful descriptions when hovering over package.jso
 ![Demo](./images/example.gif)
 
 - Hover over npm scripts to see descriptions
-- Supports custom documentation via `.vscode/script-docs.json`
+- Supports custom documentation via `.vscode/script-docs.json` in a nested structure.
+- Automatically converts old `.vscode/script-docs.json` format upon loading.
+- Documentation cache automatically reloads when `.vscode/script-docs.json` is changed, created, or deleted.
 - Built-in documentation for common scripts
 - Easy to customize and extend
 
@@ -19,14 +21,27 @@ VS Code extension that shows helpful descriptions when hovering over package.jso
 
 ## Custom Descriptions
 
-Create `.vscode/script-docs.json` in your project:
+Create or update `.vscode/script-docs.json` in your project's workspace root. The structure now supports multiple `package.json` files using their relative paths as keys:
 
 ```json
 {
-  "dev": "Starts development server",
-  "build": "Creates production build"
+  "package.json": {
+    "start": "Starts the main application",
+    "test": "Runs all tests"
+  },
+  "packages/frontend/package.json": {
+    "dev": "Starts frontend development server",
+    "build": "Builds frontend assets"
+  },
+  "packages/backend/package.json": {
+    "start:dev": "Starts backend server in dev mode"
+  }
 }
 ```
+
+If you have an existing `.vscode/script-docs.json` with the old flat structure, it will be automatically converted to the new nested structure format the first time the extension loads it.
+
+Use the command `Package Scripts Hover: Create/Update Script Documentation` to automatically generate/update this file based on all package.json files found in your workspace.
 
 ## Requirements
 
@@ -37,7 +52,7 @@ VS Code version 1.77.0 or higher
 This extension contributes the following settings:
 
 - `packageScriptsHover.enabled`: Enable/disable hover descriptions
-- `packageScriptsHover.customDocsPath`: Path to custom documentation file
+- `packageScriptsHover.customDocsPath`: Path to custom documentation file (defaults to `.vscode/script-docs.json`)
 
 ## Known Issues
 
@@ -48,6 +63,13 @@ Report issues at GitHub Issues
 https://github.com/oinochoe/vscode-package-scripts-hover/issues
 
 ## Release Notes
+
+### 0.1.0
+
+- Add support for nested package.json structures by scanning all package.json files in the workspace and using a nested structure in `.vscode/script-docs.json`.
+- Implement automatic conversion of old `.vscode/script-docs.json` format to the new nested structure upon loading.
+- Add automatic documentation cache reload when `.vscode/script-docs.json` is changed, created, or deleted (with debounce).
+- Update `createDocs` command to scan all package.json files and merge into the central `.vscode/script-docs.json`.
 
 ### 0.0.2 (2024-03-26)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "package-scripts-hover",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "package-scripts-hover",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "package-scripts-hover",
   "displayName": "Package Scripts Hover",
   "description": " Shows helpful descriptions when hovering over package.json scripts",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "license": "MIT",
   "engines": {
     "vscode": ">=1.77.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,95 +4,179 @@ import * as path from "path";
 
 let hoverProvider: vscode.Disposable | undefined;
 
+// File system watcher for script-docs.json
+let scriptDocsWatcher: vscode.FileSystemWatcher | undefined;
+
+// Debounce function implementation
+function debounce<T extends (...args: any[]) => void>(
+  func: T,
+  wait: number
+): (...args: Parameters<T>) => void {
+  let timeout: NodeJS.Timeout | null = null;
+
+  return function (...args: Parameters<T>): void {
+    const later = () => {
+      timeout = null;
+      func(...args);
+    };
+
+    if (timeout !== null) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(later, wait);
+  };
+}
+
+// Debounced function to clear the provider's cache
+let debouncedClearCache:
+  | ((provider: PackageJsonHoverProvider) => void)
+  | undefined;
+
 /**
- * Creates script-docs.json template by analyzing the current package.json
- * This will generate a template with descriptions for all npm scripts
- *
- * Process:
- * 1. Find workspace and package.json
- * 2. Create .vscode directory if it doesn't exist
- * 3. Generate script-docs.json with template descriptions
- * 4. Open the file for editing
+ * Analyzes package.json files in the workspace and updates the .vscode/script-docs.json file.
+ * This function will read the existing script-docs.json, merge new script findings,
+ * and write the updated content back.
  */
-async function createScriptDocs() {
+async function updateScriptDocsForWorkspace() {
   try {
-    // Check for workspace
     const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders) {
+    if (!workspaceFolders || workspaceFolders.length === 0) {
       throw new Error("No workspace folder found");
     }
 
-    // Look for package.json in the workspace
-    const packageJsonFiles = await vscode.workspace.findFiles(
-      "**/package.json",
-      "**/node_modules/**"
-    );
-    if (packageJsonFiles.length === 0) {
-      throw new Error("No package.json found in workspace");
-    }
-
-    // Read and parse package.json
-    const packageJsonContent = await vscode.workspace.fs.readFile(
-      packageJsonFiles[0]
-    );
-    const packageJson = JSON.parse(packageJsonContent.toString());
-
-    if (!packageJson.scripts) {
-      throw new Error("No scripts found in package.json");
-    }
+    const workspaceRoot = workspaceFolders[0].uri.fsPath;
+    const vscodePath = path.join(workspaceRoot, ".vscode");
+    const scriptDocsPath = path.join(vscodePath, "script-docs.json");
+    const scriptDocsUri = vscode.Uri.file(scriptDocsPath);
 
     // Create .vscode directory if it doesn't exist
-    const vscodePath = path.join(workspaceFolders[0].uri.fsPath, ".vscode");
     try {
       await vscode.workspace.fs.createDirectory(vscode.Uri.file(vscodePath));
     } catch (error) {
       // Ignore if directory already exists
     }
 
-    // Set up path for script-docs.json
-    const scriptDocsPath = path.join(vscodePath, "script-docs.json");
-    const scriptDocsUri = vscode.Uri.file(scriptDocsPath);
+    let existingDocs: Record<string, Record<string, string>> = {};
+    let fileExists = false;
 
-    // Check if script-docs.json already exists
+    // Read existing script-docs.json if it exists
     try {
-      await vscode.workspace.fs.stat(scriptDocsUri);
-      // Ask for confirmation before overwriting
-      const answer = await vscode.window.showWarningMessage(
-        "script-docs.json already exists. Do you want to overwrite it?",
-        "Yes",
-        "No"
+      const content = await vscode.workspace.fs.readFile(scriptDocsUri);
+      existingDocs = JSON.parse(content.toString());
+      fileExists = true;
+      vscode.window.showInformationMessage(
+        "Existing script-docs.json found. Merging new scripts."
       );
-      if (answer !== "Yes") {
-        return;
-      }
     } catch (error) {
-      // File doesn't exist, proceed with creation
+      // File not found is expected for the first run
+      if (
+        error instanceof vscode.FileSystemError &&
+        error.code === "FileNotFound"
+      ) {
+        vscode.window.showInformationMessage(
+          "script-docs.json not found. Creating a new one."
+        );
+      } else {
+        console.error("Error reading existing script-docs.json:", error);
+        vscode.window.showErrorMessage(
+          "Failed to read existing script-docs.json."
+        );
+        // Proceed with empty existingDocs
+      }
     }
 
-    // Generate template content for each script
-    const template: Record<string, string> = {};
-    Object.keys(packageJson.scripts).forEach((scriptName) => {
-      template[
-        scriptName
-      ] = `Description for '${scriptName}' script: ${packageJson.scripts[scriptName]}`;
-    });
-
-    // Write the template to script-docs.json
-    await vscode.workspace.fs.writeFile(
-      scriptDocsUri,
-      Buffer.from(JSON.stringify(template, null, 2), "utf-8")
+    // Find all package.json files excluding node_modules
+    const packageJsonFiles = await vscode.workspace.findFiles(
+      "**/package.json",
+      "**/node_modules/**"
     );
 
-    // Open the newly created file for editing
+    if (packageJsonFiles.length === 0) {
+      if (!fileExists) {
+        throw new Error(
+          "No package.json files found in workspace and no existing script-docs.json."
+        );
+      } else {
+        vscode.window.showInformationMessage(
+          "No package.json files found in workspace, but existing script-docs.json will be kept."
+        );
+        // If no package.json found but file exists, keep existingDocs
+        await vscode.workspace.fs.writeFile(
+          scriptDocsUri,
+          Buffer.from(JSON.stringify(existingDocs, null, 2), "utf-8")
+        );
+        const document = await vscode.workspace.openTextDocument(scriptDocsUri);
+        await vscode.window.showTextDocument(document);
+        return;
+      }
+    }
+
+    const newDocs: Record<string, Record<string, string>> = {};
+
+    for (const fileUri of packageJsonFiles) {
+      try {
+        const packageJsonContent = await vscode.workspace.fs.readFile(fileUri);
+        const packageJson = JSON.parse(packageJsonContent.toString());
+        const relativePath = vscode.workspace.asRelativePath(fileUri);
+
+        newDocs[relativePath] = newDocs[relativePath] || {}; // Initialize if not exists
+
+        if (packageJson.scripts) {
+          Object.keys(packageJson.scripts).forEach((scriptName) => {
+            // Preserve existing description if available, otherwise use a template
+            const existingDescription =
+              existingDocs[relativePath]?.[scriptName];
+            newDocs[relativePath][scriptName] =
+              existingDescription ||
+              `Description for '${scriptName}' script in ${relativePath}: ${packageJson.scripts[scriptName]}`;
+          });
+        } else {
+          // If a package.json had scripts before but now doesn't, we keep its existing docs
+          if (existingDocs[relativePath]) {
+            newDocs[relativePath] = existingDocs[relativePath];
+          } else {
+            newDocs[relativePath] = {}; // Include if it's a new package.json without scripts
+          }
+        }
+      } catch (readError) {
+        console.error(
+          `Failed to read or parse ${fileUri.fsPath}: ${readError}`
+        );
+        // Include an entry indicating failure, preserving existing docs if any
+        if (existingDocs[vscode.workspace.asRelativePath(fileUri)]) {
+          newDocs[vscode.workspace.asRelativePath(fileUri)] =
+            existingDocs[vscode.workspace.asRelativePath(fileUri)];
+        } else {
+          newDocs[vscode.workspace.asRelativePath(fileUri)] = {
+            __error__: `Failed to process: ${
+              readError instanceof Error ? readError.message : String(readError)
+            }`,
+          };
+        }
+      }
+    }
+
+    // Merge any packages from existingDocs that were not found in the current scan
+    for (const existingPath in existingDocs) {
+      if (!newDocs[existingPath]) {
+        newDocs[existingPath] = existingDocs[existingPath];
+      }
+    }
+
+    await vscode.workspace.fs.writeFile(
+      scriptDocsUri,
+      Buffer.from(JSON.stringify(newDocs, null, 2), "utf-8")
+    );
+
     const document = await vscode.workspace.openTextDocument(scriptDocsUri);
     await vscode.window.showTextDocument(document);
 
     vscode.window.showInformationMessage(
-      "script-docs.json has been created successfully!"
+      "script-docs.json has been updated successfully!"
     );
   } catch (error) {
     vscode.window.showErrorMessage(
-      `Failed to create script-docs.json: ${
+      `Failed to update script-docs.json: ${
         error instanceof Error ? error.message : "Unknown error"
       }`
     );
@@ -107,6 +191,50 @@ export function activate(context: vscode.ExtensionContext) {
   console.log('Extension "package-scripts-hover" is now active');
 
   const provider = new PackageJsonHoverProvider();
+
+  // Initialize debounced clear cache function
+  debouncedClearCache = debounce((p: PackageJsonHoverProvider) => {
+    console.log("script-docs.json changed, reloading documentation cache.");
+    p.clearCache();
+    vscode.window.showInformationMessage(
+      "Package Scripts documentation cache reloaded."
+    );
+  }, 500); // 500ms debounce time
+
+  // Create a file system watcher for script-docs.json
+  // The pattern matches .vscode/script-docs.json anywhere in the workspace
+  scriptDocsWatcher = vscode.workspace.createFileSystemWatcher(
+    "**/.vscode/script-docs.json",
+    false, // ignoreCreateEvents
+    false, // ignoreChangeEvents - we want changes
+    false // ignoreDeleteEvents - we want deletions
+  );
+
+  // Register event listeners for the watcher
+  scriptDocsWatcher.onDidChange((uri) => {
+    // When the file changes, clear the cache after debounce time
+    if (debouncedClearCache) {
+      debouncedClearCache(provider);
+    }
+  });
+
+  scriptDocsWatcher.onDidCreate((uri) => {
+    // When the file is created, clear the cache immediately (or after short debounce)
+    if (debouncedClearCache) {
+      // Use a shorter debounce or no debounce for creation if preferred
+      debouncedClearCache(provider);
+    }
+  });
+
+  scriptDocsWatcher.onDidDelete((uri) => {
+    // When the file is deleted, clear the cache immediately
+    if (debouncedClearCache) {
+      debouncedClearCache(provider);
+    }
+  });
+
+  // Add the watcher to the extension's subscriptions so it's disposed on deactivate
+  context.subscriptions.push(scriptDocsWatcher);
 
   // Register enable command
   const enableCommand = vscode.commands.registerCommand(
@@ -161,7 +289,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Register create docs command
   const createDocsCommand = vscode.commands.registerCommand(
     "package-scripts-hover.createDocs",
-    createScriptDocs
+    updateScriptDocsForWorkspace
   );
 
   // Register default hover provider
@@ -182,11 +310,17 @@ export function activate(context: vscode.ExtensionContext) {
 
 /**
  * Deactivates the extension
- * Cleans up the hover provider
+ * Cleans up resources
  */
 export function deactivate() {
   if (hoverProvider) {
     hoverProvider.dispose();
     hoverProvider = undefined;
   }
+  if (scriptDocsWatcher) {
+    scriptDocsWatcher.dispose();
+    scriptDocsWatcher = undefined;
+  }
+  // Clear debounced function reference
+  debouncedClearCache = undefined;
 }

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -3,13 +3,14 @@
  * @author yeongmin
  */
 import * as vscode from "vscode";
+import path from "path";
 
 /**
- * Type definition for script documentation key-value pairs
- * Key: script name (e.g., 'build', 'test')
- * Value: description of what the script does
+ * Type definition for script documentation in a nested-like structure
+ * Key: package.json relative path (e.g., 'package.json', 'packages/frontend/package.json')
+ * Value: Script documentation for that package.json (Record<scriptName, description>)
  */
-type ScriptDocs = Record<string, string>;
+type ScriptDocs = Record<string, Record<string, string>>;
 
 /**
  * Provides hover functionality for package.json scripts
@@ -18,20 +19,6 @@ type ScriptDocs = Record<string, string>;
 export class PackageJsonHoverProvider implements vscode.HoverProvider {
   /** Cached documentation to avoid repeated file system reads */
   private cachedDocs: ScriptDocs | null = null;
-
-  /**
-   * Default documentation for common npm scripts
-   * These will be used if no custom documentation is provided
-   * Can be overridden by custom docs in .vscode/script-docs.json
-   */
-  private readonly defaultDocs: ScriptDocs = {
-    dev: "Runs development server (default port: 5173)",
-    build: "Creates a production build",
-    preview: "Previews the built version locally",
-    test: "Runs tests",
-    lint: "Runs code linting",
-    format: "Formats the codebase",
-  };
 
   /**
    * Clears the cached documentation
@@ -53,90 +40,193 @@ export class PackageJsonHoverProvider implements vscode.HoverProvider {
     position: vscode.Position,
     token: vscode.CancellationToken
   ): Promise<vscode.Hover | null> {
-    // Parse the entire document as JSON
-    const text = document.getText();
-    let packageJson: { scripts?: Record<string, string> };
+    // Ensure the document is a package.json file
+    if (document.fileName.endsWith("package.json")) {
+      // Parse the entire document as JSON
+      const text = document.getText();
+      let packageJson: { scripts?: Record<string, string> };
 
-    try {
-      packageJson = JSON.parse(text);
-    } catch (e) {
-      return null; // Return null if JSON is invalid
+      try {
+        packageJson = JSON.parse(text);
+      } catch (e) {
+        return null; // Return null if JSON is invalid
+      }
+
+      // Extract the script name from the current line
+      const line = document.lineAt(position.line).text;
+      // Regex to find script names, handling potential commas and surrounding whitespace
+      const scriptMatch = line.match(/^\s*"([a-zA-Z0-9_:-]+)"\s*:/);
+
+      if (!scriptMatch || scriptMatch.length < 2) {
+        return null; // Return null if not hovering over a script name
+      }
+
+      const scriptName = scriptMatch[1];
+
+      // Check if the identified name is actually a script key
+      if (!packageJson.scripts?.[scriptName]) {
+        return null; // Return null if script doesn't exist in package.json
+      }
+
+      // Get the relative path of the current package.json file
+      const relativePath = vscode.workspace.asRelativePath(document.uri);
+
+      // Load documentation from the main script-docs.json file
+      const scriptDocs = await this.loadCustomDocs();
+
+      // Find the documentation for the current package.json and script
+      const packageDocs = scriptDocs?.[relativePath];
+      const description =
+        packageDocs?.[scriptName] || "No description available.";
+
+      // Get the command for the script from the current document
+      const command = packageJson.scripts[scriptName];
+
+      // Create rich markdown content for the hover
+      const content = new vscode.MarkdownString("", true);
+      content.isTrusted = true; // Enable trusted content (required for some markdown features)
+      content.supportHtml = true; // Enable HTML support in the hover
+
+      // Build the hover content with markdown formatting
+      content.appendMarkdown(`### \`${scriptName}\`\n\n`);
+      content.appendMarkdown(`**Description:** ${description}\n\n`);
+      content.appendMarkdown(`**Command:** \`${command}\`\n\n`);
+      content.appendMarkdown(`Usage: \`npm run ${scriptName}\``);
+
+      return new vscode.Hover(content);
     }
 
-    // Extract the script name from the current line
-    const line = document.lineAt(position.line).text;
-    const lineMatch = line.match(/"([^"]+)":/);
-    if (!lineMatch) {
-      return null; // Return null if not hovering over a script name
-    }
-
-    const scriptName = lineMatch[1];
-    if (!packageJson.scripts?.[scriptName]) {
-      return null; // Return null if script doesn't exist in package.json
-    }
-
-    // Load documentation and prepare hover content
-    const docs = await this.loadCustomDocs();
-    const command = packageJson.scripts[scriptName];
-    const description = docs[scriptName] || "No description available.";
-
-    // Create rich markdown content for the hover
-    const content = new vscode.MarkdownString("", true);
-    content.isTrusted = true; // Enable trusted content (required for some markdown features)
-    content.supportHtml = true; // Enable HTML support in the hover
-
-    // Build the hover content with markdown formatting
-    content.appendMarkdown(`### \`${scriptName}\`\n\n`);
-    content.appendMarkdown(`**Description:** ${description}\n\n`);
-    content.appendMarkdown(`**Command:** \`${command}\`\n\n`);
-    content.appendMarkdown(`Usage: \`npm run ${scriptName}\``);
-
-    return new vscode.Hover(content);
+    return null; // Not a package.json file
   }
 
   /**
-   * Loads custom documentation from the workspace
+   * Loads custom documentation from .vscode/script-docs.json
+   * Automatically converts old single-file structure to nested structure if detected.
    * @param force - If true, bypasses cache and forces a reload
-   * @returns A promise that resolves to the merged documentation (custom + default)
+   * @returns A promise that resolves to the documentation, or null if file not found or invalid
    */
-  private async loadCustomDocs(force: boolean = false): Promise<ScriptDocs> {
+  private async loadCustomDocs(
+    force: boolean = false
+  ): Promise<ScriptDocs | null> {
     // Return cached docs if available and force reload not requested
     if (this.cachedDocs && !force) {
       return this.cachedDocs;
     }
 
     try {
-      // Get custom docs path from extension settings
-      const config = vscode.workspace.getConfiguration("packageScriptsHover");
-      const customDocsPath =
-        config.get<string>("customDocsPath") ?? ".vscode/script-docs.json";
-
-      // Search for custom documentation file
-      const files = await vscode.workspace.findFiles(customDocsPath, null, 1);
-
-      if (files.length > 0) {
-        // Read and parse custom documentation
-        const content = await vscode.workspace.fs.readFile(files[0]);
-        const customDocs = JSON.parse(content.toString()) as ScriptDocs;
-
-        // Merge custom docs with default docs (custom takes precedence)
-        this.cachedDocs = {
-          ...this.defaultDocs,
-          ...customDocs,
-        };
-      } else {
-        // Use default docs if no custom docs found
-        this.cachedDocs = this.defaultDocs;
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (!workspaceFolders || workspaceFolders.length === 0) {
+        return null; // No workspace, cannot load docs
       }
+
+      const workspaceRoot = workspaceFolders[0].uri.fsPath;
+      const scriptDocsPath = path.join(
+        workspaceRoot,
+        ".vscode",
+        "script-docs.json"
+      );
+      const scriptDocsUri = vscode.Uri.file(scriptDocsPath);
+
+      let rawDocs: any;
+      try {
+        // Read the existing file
+        const content = await vscode.workspace.fs.readFile(scriptDocsUri);
+        rawDocs = JSON.parse(content.toString());
+
+        // TODO: Consider removing this entire 'looksLikeOldStructure' block
+        // in a future release after sufficient time has passed for users
+        // to migrate to the new nested script-docs.json format.
+        // Check if it looks like the old structure (flat object, no path-like keys)
+        const looksLikeOldStructure =
+          rawDocs &&
+          typeof rawDocs === "object" &&
+          !Array.isArray(rawDocs) &&
+          Object.keys(rawDocs).length > 0 && // Avoid converting empty object
+          !Object.keys(rawDocs).some(
+            (key) =>
+              key.includes("/") || key.includes("\\") || key === "package.json"
+          );
+
+        if (looksLikeOldStructure) {
+          vscode.window.showInformationMessage(
+            "Detected old script-docs.json structure. Converting to nested format."
+          );
+
+          const newStructure: ScriptDocs = {
+            "package.json": rawDocs as Record<string, string>,
+          };
+
+          // Find other package.json files and add them to the new structure if not present
+          const packageJsonFiles = await vscode.workspace.findFiles(
+            "**/package.json",
+            "**/node_modules/**"
+          );
+          for (const fileUri of packageJsonFiles) {
+            const relativePath = vscode.workspace.asRelativePath(fileUri);
+            if (
+              relativePath !== "package.json" &&
+              !newStructure[relativePath]
+            ) {
+              newStructure[relativePath] = {}; // Add with empty docs
+            }
+          }
+
+          // Write the converted structure back to the file
+          await vscode.workspace.fs.writeFile(
+            scriptDocsUri,
+            Buffer.from(JSON.stringify(newStructure, null, 2), "utf-8")
+          );
+          vscode.window.showInformationMessage(
+            "script-docs.json successfully converted to nested format."
+          );
+          rawDocs = newStructure; // Use the new structure going forward
+        } else if (
+          rawDocs &&
+          typeof rawDocs === "object" &&
+          !Array.isArray(rawDocs)
+        ) {
+          // Assume it's the new structure or an empty/valid object
+          // Do nothing, use rawDocs as is
+        } else {
+          // Handle cases where the file content is not a valid object (e.g., array, string, null)
+          throw new Error("script-docs.json has an invalid format.");
+        }
+      } catch (readFileError) {
+        // Handle file not found specifically
+        if (
+          readFileError instanceof vscode.FileSystemError &&
+          readFileError.code === "FileNotFound"
+        ) {
+          console.log("script-docs.json not found.");
+          this.cachedDocs = null; // Ensure cache is null if file doesn't exist
+          return null; // File not found
+        } else {
+          // Handle parsing or other read errors
+          console.error(
+            "Error reading or parsing script-docs.json:",
+            readFileError instanceof Error
+              ? readFileError.message
+              : readFileError
+          );
+          vscode.window.showErrorMessage(
+            "Failed to read script-docs.json. Please check file format."
+          );
+          this.cachedDocs = null; // Clear cache on error
+          return null; // Error reading/parsing
+        }
+      }
+
+      // If we reached here, rawDocs holds the valid (potentially converted) data
+      this.cachedDocs = rawDocs as ScriptDocs;
+      return this.cachedDocs;
     } catch (error) {
-      // Log error and fallback to default docs
+      // Catch any unexpected errors during the process
       console.error(
-        "Error loading custom docs:",
+        "Unexpected error in loadCustomDocs:",
         error instanceof Error ? error.message : error
       );
-      this.cachedDocs = this.defaultDocs;
+      this.cachedDocs = null;
+      return null;
     }
-
-    return this.cachedDocs;
   }
 }


### PR DESCRIPTION
This commit introduces support for projects with multiple package.json files, such as monorepos or nested modules.

Key changes include:
- Scan all package.json files in the workspace (excluding node_modules).
- Use a single .vscode/script-docs.json file with a nested structure (package.json path as key) to store documentation for all scripts.
- Automatically convert the old flat script-docs.json format to the new nested format when the file is loaded.
- Implement automatic documentation cache reload using debounce when .vscode/script-docs.json is changed, created, or deleted.
- Update the "Create Script Documentation Template" command to scan all package.json files and merge scripts into the central documentation file.
- Update README.md and CHANGELOG.md to reflect the new features and version (0.1.0).
- Remove the old `createScriptDocs` function as it's superseded by the updated command logic.